### PR TITLE
Change navigation bar icons

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -1,5 +1,7 @@
 import { Tabs } from "expo-router";
 import { View } from "react-native";
+import { Ionicons } from '@expo/vector-icons'; // Import Ionicons from @expo/vector-icons
+
 
 function _layout() {
   return (
@@ -7,15 +9,27 @@ function _layout() {
     <Tabs>
       <Tabs.Screen
         name="feed"
-        options={{ tabBarLabel: "Feed", headerTitle: "Feed" }}
+        options={{ 
+          tabBarLabel: "Feed", 
+          headerTitle: "Feed",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="home" size={30} color={color} /> // Change the icon here
+          ),
+        }}
       />
       <Tabs.Screen
         name="search"
-        options={{ tabBarLabel: "Search", headerTitle: "Search" }}
+        options={{ tabBarLabel: "Search", headerTitle: "Search",
+        tabBarIcon: ({ color, size }) => (
+          <Ionicons name="list" size={30} color={color} /> // Change the icon here
+        ), }}
       />
       <Tabs.Screen
         name="create-recipe"
-        options={{ tabBarLabel: "Create", headerTitle: "Create Recipe" }}
+        options={{ tabBarLabel: "Create", headerTitle: "Create Recipe",
+        tabBarIcon: ({ color, size }) => (
+          <Ionicons name="create" size={30} color={color} /> // Change the icon here
+        ), }}
       />
       <Tabs.Screen
         name="lists"
@@ -23,11 +37,17 @@ function _layout() {
           tabBarLabel: "Lists",
           headerTitle: "Lists",
           headerShown: false,
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="list" size={30} color={color} /> // Change the icon here
+          ),
         }}
       />
       <Tabs.Screen
         name="profile"
-        options={{ tabBarLabel: "Profile", headerTitle: "Profile " }}
+        options={{ tabBarLabel: "Profile", headerTitle: "Profile",
+        tabBarIcon: ({ color, size }) => (
+          <Ionicons name="ios-person" size={30} color={color} /> // Change the icon here
+        ), }}
       />
     </Tabs>
   );


### PR DESCRIPTION
Changed the navigation bar icons from generic triangles to representative icons for each tab.

I am using a functionality of expo that has built-in icons, so there is no need for any package installation.

After messing with implementing the auth for the profile page for a few hours, I determined that it would be done over the weekend, and wouldn't be part of my Pull Request assignment. I underestimated how much trouble that would bring.